### PR TITLE
docs: fix rust-lang's hyperlink to the correct language

### DIFF
--- a/articles/getting-started-with-rust.mdx
+++ b/articles/getting-started-with-rust.mdx
@@ -6,7 +6,7 @@ description: "Learn how to get started on Square Cloud with Rust"
 ---
 ## 🚀 Introduction
 
-- Before you begin, make sure you have Rust on your system. If you don't have them yet, you can download them from the [official Rust website](https://www.rust-lang.org/pt-BR/tools/install).
+- Before you begin, make sure you have Rust on your system. If you don't have them yet, you can download them from the [official Rust website](https://www.rust-lang.org/tools/install).
 - Next, you will need to create an account on Square Cloud, which can be done through the [login page](https://squarecloud.app/login). You can use either your email or Discord, or both, to create an account.
 - Finally, you need to have an active paid plan on your account. You can view our plans and purchase one according to your needs [here](https://squarecloud.app/plans).
 


### PR DESCRIPTION
IDK if it makes sense for an English website to redirect to a Portuguese website, so I changed the Rust website hyperlink to use English instead of Portuguese
I hope this is useful 😊