### PR TITLE
Update auth commands guides

### DIFF
--- a/cli-reference/authentication.mdx
+++ b/cli-reference/authentication.mdx
@@ -11,7 +11,7 @@ description: "Learn what it takes to authenticate to the Square Cloud CLI."
     <Step title="Authenticate">
         Authenticate to the Square Cloud CLI using the following command:
         ```bash
-        squarecloud login
+        squarecloud auth login
         ```
 
         You will be prompted to enter your API key.
@@ -21,6 +21,11 @@ description: "Learn what it takes to authenticate to the Square Cloud CLI."
         ```
 
         After entering your API key, you will be authenticated to the Square Cloud CLI.
+
+        You can skip the prompt by passing your API key with the `--token` flag:
+        ```bash
+        squarecloud auth login --token=<API key>
+        ```
     </Step>
 </Steps>
 

--- a/cli-reference/commands.mdx
+++ b/cli-reference/commands.mdx
@@ -26,12 +26,11 @@ The Square Cloud CLI provides the following primary commands:
 
         Available Commands:
           app         Do some actions with your applications
-          apps        List all your Square Cloud applications
+          auth        Manage your authentication with Square Cloud
+          backup      Manage your backups
           commit      Commit your application to Square Cloud
           help        Help about any command
-          login       Login to Square Cloud
           upload      Upload your application to Square Cloud
-          whoami      Print the user informations associated with current Square Cloud Token
           zip         Zip the current folder
 
         Flags:
@@ -41,11 +40,11 @@ The Square Cloud CLI provides the following primary commands:
         Use "squarecloud [command] --help" for more information about a command.
         ```
     </Tab>
-    <Tab title="squarecloud login">
+    <Tab title="squarecloud auth login">
         Command to authenticate to the Square Cloud CLI using your API key.
 
         ```bash
-        squarecloud login
+        squarecloud auth login
         ```
 
         You will be prompted to enter your API key.
@@ -62,11 +61,11 @@ The Square Cloud CLI provides the following primary commands:
 
         After entering your API key, you will be authenticated to the Square Cloud CLI. 😁
     </Tab>
-    <Tab title="squarecloud whoami">
+    <Tab title="squarecloud auth whoami">
         Command to print user information associated with the current Square Cloud Token.
 
         ```bash
-        squarecloud whoami
+        squarecloud auth whoami
         ```
 
         You will see the user information associated with the current Square Cloud Token.


### PR DESCRIPTION
Current instructions tell users to run `squarecloud login` or `whoami` commands, even though these have been moved into `squarecloud auth`.

This PR also suggests using `--token` flag as a way of skipping the API key prompt in the `auth login` command.