### PR TITLE
Updating SDKs pages

### DIFF
--- a/cli-reference/commands.mdx
+++ b/cli-reference/commands.mdx
@@ -103,11 +103,11 @@ The Square Cloud CLI provides the following primary commands:
 The CLI provides the following commands to manage your applications:
 
 <Tabs>
-    <Tab title="squarecloud apps">
+    <Tab title="squarecloud app list">
         Command to list all your Square Cloud applications.
 
         ```bash
-        squarecloud apps
+        squarecloud app list
         ```
 
         You will see a list of all your Square Cloud applications.
@@ -138,12 +138,15 @@ The CLI provides the following commands to manage your applications:
 
         Available Commands:
           backup      Create a backup of you application
+          commit      Commit your application to Square Cloud 
           delete      Delete your application
+          list        List all your applications
           logs        See your application logs
           restart     Restart your application
           start       Start your application
           status      Show the status of your application
           stop        Stop your application
+          upload      Upload your application to Square Cloud
 
         Flags:
           -h, --help   help for app
@@ -151,7 +154,7 @@ The CLI provides the following commands to manage your applications:
         Use "squarecloud app [command] --help" for more information about a command.
         ```
     </Tab> 
-</Tabs>
+</Tabs> 
 
 ## Deployment Command
 The CLI provides the following command to deploy your application:

--- a/cli-reference/installation.mdx
+++ b/cli-reference/installation.mdx
@@ -33,22 +33,13 @@ yarn global add @squarecloud/cli
 To update the CLI, you can run the following command:
 <CodeGroup>
 ```bash Windows
-squarecloud update
+npm update -g @squarecloud/cli
 ```
 ```bash Linux, macOS, and WSL
 curl -fsSL https://cli.squarecloud.app/install | bash
 ```
 </CodeGroup>
 
-```bash Output
-$: squarecloud update
-Downloading checksums...
-Downloading binaries from github release...
-https://github.com/squarecloudofc/cli/releases/download/v2.1.1/squarecloud_windows_amd64.zip
-Validating file...
-Extracting file to C:\Users\squarecloud\AppData\Roaming\squarecloud
-Square Cloud CLI updated to version 2.1.1
-```
 And that's it! You have successfully updated the Square Cloud CLI. 🎉
 
 ## Next steps

--- a/sdks/js/client.mdx
+++ b/sdks/js/client.mdx
@@ -37,8 +37,7 @@ npm i @squarecloud/api
 Using the get started endpoint, you can obtain a user object representing the user associated with the API key, as well as a list of applications associated with the user.
 
 ```javascript 
-const user = await api.users.get();
-const application = user.applications.get("Application ID");
+const user = await api.user.get();
 
 console.log(user.applications); // List of Application's
 ```
@@ -53,5 +52,5 @@ console.log(app); // Output: application object
 ```
 
 ```javascript Obtaining All Applications
-console.log(user.applications); // user = api.users.get() [Promise]
+console.log(user.applications); // user = api.user.get() [Promise]
 ```

--- a/sdks/js/commit_and_upload.mdx
+++ b/sdks/js/commit_and_upload.mdx
@@ -19,11 +19,8 @@ description: "In this section you will learn how to make commits and uploads usi
     const fileContent = Buffer.from("Your file content");
     const fileName = "file.txt";
 
-    // Optionally, set whether the application should restart after the commit
-    const shouldRestart = true;
-
     // Perform the commit operation
-    const success = await application.commit(fileContent, fileName, shouldRestart);
+    const success = await application.commit(fileContent, fileName);
 
     // Handle the result accordingly
     if (success) {

--- a/sdks/py/commit_and_upload.mdx
+++ b/sdks/py/commit_and_upload.mdx
@@ -38,7 +38,7 @@ zip file is.
 
 ## Making a upload
 
-To upload an application, you only use the [Client] and the CLI.
+To upload an application, you can use only  the [Client].
 
 <Tabs>
     <Tab title="Using Client">

--- a/sdks/py/installation.mdx
+++ b/sdks/py/installation.mdx
@@ -7,14 +7,4 @@ description: "Learn how to install the squarecloud-api package for seamless inte
 pip install squarecloud-api
 ```
 
-If you intend to use this SDK for command-line interface (CLI) operations, consider installing it with pipx:
-
-```bash
-pipx install squarecloud-api
-```
-
-This will ensure a clean and isolated installation, allowing you to efficiently manage dependencies for your projects.
-
-For more information on how to install pipx, visit the official website: https://pipx.pypa.io/stable/installation.
-
 Now you can seamlessly integrate the squarecloud-api into your development workflow 😊.


### PR DESCRIPTION
- Removed CLI citations in Python SDK page
- Removed `shouldRestard` from JS SDK page
- Changed `api.users` to `api.user` on JS SDK page since `api.users` is now deprecated.