### PR TITLE
fix: punctuation error

### DIFF
--- a/services/blob.mdx
+++ b/services/blob.mdx
@@ -50,7 +50,7 @@ Square Cloud supports a wide range of file types, making it a versatile solution
 | Image       | .jpeg, .png, .apng, .tiff, .gif, .webp, .bmp, .svg, .ico, .cur, .heic, .heif |
 | Audio       | .mp3, .mp4, .wav, .ogg, .opus, .mpeg, .aac                                   | 
 | Text        | .txt, .html, .css, .csv, .x-sql                                              |
-| Application | .xml, .sql, , .x-sql, .sqlite3, .pdf, .json, .javascript, .p12               |
+| Application | .xml, .sql, .x-sql, .sqlite3, .pdf, .json, .javascript, .p12                 |
 
 <Note> If you have a specific file type that you'd like to use with Square Cloud, please [contact us](/contact).</Note>
 


### PR DESCRIPTION
This PR fixes a formatting issue in the documentation where there was an extra comma between the `.sql` and `.x-sql` file extensions in the **Application** column.