### PR TITLE
Fixing missing version on database create route

### DIFF
--- a/api-reference/endpoint/databases/create.mdx
+++ b/api-reference/endpoint/databases/create.mdx
@@ -26,7 +26,7 @@ authMethod: "none"
   The database type, Mongo, Redis or any other available. 
 </ParamField>
 <ParamField body="version" type="string" placeholder="Version number" required>
-  The version of Database. Check the versions available in ...
+  The version of Database. Mongo 8.0.11 and Redis 7.4.5.
 </ParamField>
 
 ## Response


### PR DESCRIPTION
Added this info: 
   Mongo 8.0.11
   Redis 7.4.5

since they are not present anywhere for now.
